### PR TITLE
Including also the parallel snippet call sample

### DIFF
--- a/src/main/webapp/parallel.html
+++ b/src/main/webapp/parallel.html
@@ -31,7 +31,7 @@
     <hr/>
 
     <p>The Markup:</p>
-    <div data-lift="github?file=src/main/webapp/parallel.html&lines=12-15"></div>
+    <div data-lift="github?file=src/main/webapp/parallel.html&lines=12-20"></div>
 
 
     <p>The Scala Code:</p>


### PR DESCRIPTION
The sample page only shows the inline call, so include also the parallel one (that of course is the interesting one)
